### PR TITLE
Prevent default behavior for arrow key input.

### DIFF
--- a/src/Timesheet.js
+++ b/src/Timesheet.js
@@ -123,10 +123,12 @@ export default class Timesheet extends React.Component {
     arrowKeyFocus(index, event, field) {
         let newIndex = index;
         if (event.keyCode === 38) { // up
+            event.preventDefault();
             if (index <= 0) return;
             newIndex -= 1;
         }
         else if (event.keyCode === 40 || event.keyCode === 13) { // down or enter
+            event.preventDefault();
             if (index >= this.state.entries.length - 1) {
                 // only add if the last entry has text
                 if (this.state.entries[index].summary.trim() !== "") {


### PR DESCRIPTION
In the case of input type="number",
arrow keys will change the value on the input field.
This UI intends for Up and Down arrow keys
to change input focus on desktop,
while the number type input is meant to improve mobile entry.

Addresses regression introduced in #5.  Part of #1 implementation.